### PR TITLE
Implementation of the Omni-test problem

### DIFF
--- a/pymoo/problems/multi/omnitest.py
+++ b/pymoo/problems/multi/omnitest.py
@@ -1,0 +1,49 @@
+import numpy as np
+from numpy import sum, pi, sin, cos
+
+from pymoo.model.problem import Problem
+
+
+class OmniTest(Problem):
+    """
+    The Omni-test problem proposed by Deb in [1].
+
+    Parameters
+    ----------
+    n_var: number of decision variables
+
+    References
+    ----------
+    [1] Deb, K., Tiwari, S. "Omni-optimizer: A generic evolutionary algorithm for single and multi-objective optimization"
+    """
+    def __init__(self, n_var=2):
+        assert (n_var >= 2), "The dimension of the decision space should at least be 2!"
+        super().__init__(
+            n_var=n_var, n_obj=2, n_constr=0, type_var=np.double,
+            xl=np.full(n_var, 0), xu=np.full(n_var, 6)
+        )
+
+    def _evaluate(self, X, out, *args, **kwargs):
+        F1 = sum(sin(pi * X), axis=1)
+        F2 = sum(cos(pi * X), axis=1)
+        out["F"] = np.vstack((F1, F2)).T
+
+    def _calc_pareto_set(self, n_pareto_points=500):
+        # The Omni-test problem has 3^D Pareto subsets
+        num_ps = int(3 ** self.n_var)
+        h = int(n_pareto_points / num_ps)
+        PS = np.zeros((num_ps * h, self.n_var))
+
+        candidates = np.array([np.linspace(2 * m + 1, 2 * m + 3 / 2, h) for m in range(3)])
+        # generate combination indices
+        candidates_indices = [[0, 1, 2] for _ in range(self.n_var)]
+        a = np.meshgrid(*candidates_indices)
+        combination_indices = np.array(a).T.reshape(-1, self.n_var)
+        # generate 3^D combinations
+        for i in range(num_ps):
+            PS[i * h:i * h + h, :] = candidates[combination_indices[i]].T
+        return PS
+
+    def _calc_pareto_front(self, n_pareto_points=500):
+        PS = self._calc_pareto_set(n_pareto_points)
+        return self.evaluate(PS, return_values_of=["F"])

--- a/pymoo/usage/problems/usage_omni.py
+++ b/pymoo/usage/problems/usage_omni.py
@@ -1,0 +1,38 @@
+from pymoo.algorithms.nsga3 import NSGA3
+from pymoo.factory import get_reference_directions
+from pymoo.optimize import minimize
+from pymoo.problems.multi.omnitest import OmniTest
+from pymoo.visualization.scatter import Scatter
+import matplotlib.pyplot as plt
+
+problem = OmniTest(n_var=3)
+ref_dirs = get_reference_directions("das-dennis", problem.n_obj, n_partitions=30)
+PS = problem.pareto_set(5000)
+PF = problem.pareto_front(5000)
+
+algorithm = NSGA3(ref_dirs=ref_dirs)
+
+res = minimize(problem,
+               algorithm,
+               ('n_gen', 500),
+               seed=1,
+               verbose=False)
+
+fig_name = f"{algorithm.__class__.__name__} on Omni-test"
+
+# visualize decision space
+plot = Scatter(title="Decision Space")
+plot.add(PS, s=10, color='r', label="PS")
+plot.add(res.X, s=30, color='b', label="Obtained solutions")
+plot.do()
+plt.legend()
+
+# visualize objective space
+plot = Scatter(title="Objective Space")
+plot.add(PF, s=10, color='r', label="PF")
+plot.add(res.F, s=30, color='b', label="Obtained solutions")
+plot.do()
+plt.legend()
+
+plt.show()
+


### PR DESCRIPTION
I have implemented the Omni-test problem proposed by Deb in this paper: "Omni-optimizer: a generic evolutionary algorithm for single and multi-objective optimization".

The Omni-test problem is a multi-modal multi-objective optimization problem. It has $3^D$ equivalent Pareto subsets in the decision space, where $D$ is the dimension of the decision space. 

For example, when $D=3$, it has 27 equivalent Pareto subsets. The NSGA-III gives the following results:
![D=3](https://user-images.githubusercontent.com/21050064/83343803-c611c600-a331-11ea-8900-2beb1404053a.png)

And $D=2$:
![D=2](https://user-images.githubusercontent.com/21050064/83343825-04a78080-a332-11ea-8694-9530fc5fb528.png)
