### PR TITLE
Set type of population numpy array to float,

### DIFF
--- a/pymoo/model/survival.py
+++ b/pymoo/model/survival.py
@@ -28,7 +28,7 @@ class LeastInfeasibleSurvival:
         if self.clearing:
 
             # calculate the distance from each individual to another - pre-processing for the clearing
-            X = pop.get("X")
+            X = pop.get("X").astype(float)
             D = norm_eucl_dist(problem, X, X)
 
             # select by clearing using the order defined before


### PR DESCRIPTION
Sometimes `pop.get(X)` return object type instead of float, and the euclidean distance matrix can not be calculated.